### PR TITLE
feat: Implement advanced sorting options

### DIFF
--- a/src/components/IdeaList.tsx
+++ b/src/components/IdeaList.tsx
@@ -2,7 +2,8 @@ import type React from "react";
 import { useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import { useDeleteIdea, useUpdateIdea } from "@/hooks/useIdeas";
-import type { FilterOptions, ProjectIdea } from "@/types";
+import { sortIdeas } from "@/lib/utils";
+import type { FilterOptions, ProjectIdea, SortOption } from "@/types";
 import { IdeaCard } from "./IdeaCard";
 import { SearchFilter } from "./SearchFilter";
 
@@ -16,6 +17,8 @@ export const IdeaList: React.FC<IdeaListProps> = ({ ideas }) => {
 		selectedTags: [],
 		priority: "",
 	});
+	const [sortOption, setSortOption] =
+		useState<SortOption>("dateCreated-desc");
 
 	const updateMutation = useUpdateIdea();
 	const deleteMutation = useDeleteIdea();
@@ -33,6 +36,8 @@ export const IdeaList: React.FC<IdeaListProps> = ({ ideas }) => {
 
 		return matchesSearch && matchesTags && matchesPriority;
 	});
+
+	const sortedIdeas = sortIdeas(filteredIdeas, sortOption);
 
 	const handleUpdate = async (id: string, updates: Partial<ProjectIdea>) => {
 		try {
@@ -74,9 +79,11 @@ export const IdeaList: React.FC<IdeaListProps> = ({ ideas }) => {
 				ideas={ideas}
 				filters={filters}
 				onFiltersChange={setFilters}
+				sortOption={sortOption}
+				onSortChange={setSortOption}
 			/>
 
-			{filteredIdeas.length === 0 ? (
+			{sortedIdeas.length === 0 ? (
 				<div className="py-12 text-center">
 					<div className="mb-2 text-lg text-muted-foreground">
 						{ideas.length === 0
@@ -91,7 +98,7 @@ export const IdeaList: React.FC<IdeaListProps> = ({ ideas }) => {
 				</div>
 			) : (
 				<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-					{filteredIdeas.map((idea) => (
+					{sortedIdeas.map((idea) => (
 						<IdeaCard
 							key={idea.id}
 							idea={idea}

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -10,18 +10,22 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import type { FilterOptions, ProjectIdea } from "@/types";
+import type { FilterOptions, ProjectIdea, SortOption } from "@/types";
 
 interface SearchFilterProps {
 	ideas: ProjectIdea[];
 	filters: FilterOptions;
 	onFiltersChange: (filters: FilterOptions) => void;
+	sortOption: SortOption;
+	onSortChange: (sortOption: SortOption) => void;
 }
 
 export const SearchFilter: React.FC<SearchFilterProps> = ({
 	ideas,
 	filters,
 	onFiltersChange,
+	sortOption,
+	onSortChange,
 }) => {
 	const allTags = Array.from(new Set(ideas.flatMap((idea) => idea.tags)));
 
@@ -101,6 +105,35 @@ export const SearchFilter: React.FC<SearchFilterProps> = ({
 								<SelectItem value="high">High Priority</SelectItem>
 								<SelectItem value="medium">Medium Priority</SelectItem>
 								<SelectItem value="low">Low Priority</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex-1">
+						<Select value={sortOption} onValueChange={onSortChange}>
+							<SelectTrigger>
+								<SelectValue placeholder="Sort by" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="dateCreated-desc">
+									Date Created (Newest First)
+								</SelectItem>
+								<SelectItem value="dateCreated-asc">
+									Date Created (Oldest First)
+								</SelectItem>
+								<SelectItem value="dateUpdated-desc">
+									Date Updated (Newest First)
+								</SelectItem>
+								<SelectItem value="dateUpdated-asc">
+									Date Updated (Oldest First)
+								</SelectItem>
+								<SelectItem value="priority-desc">
+									Priority (High to Low)
+								</SelectItem>
+								<SelectItem value="priority-asc">
+									Priority (Low to High)
+								</SelectItem>
+								<SelectItem value="title-asc">Title (A-Z)</SelectItem>
+								<SelectItem value="title-desc">Title (Z-A)</SelectItem>
 							</SelectContent>
 						</Select>
 					</div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,50 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import type { ProjectIdea, SortOption } from "@/types";
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
+
+const priorityMap = {
+	high: 3,
+	medium: 2,
+	low: 1,
+};
+
+export const sortIdeas = (ideas: ProjectIdea[], sortBy: SortOption) => {
+	const sortedIdeas = [...ideas];
+
+	sortedIdeas.sort((a, b) => {
+		switch (sortBy) {
+			case "dateCreated-desc":
+				return (
+					new Date(b.dateCreated).getTime() - new Date(a.dateCreated).getTime()
+				);
+			case "dateCreated-asc":
+				return (
+					new Date(a.dateCreated).getTime() - new Date(b.dateCreated).getTime()
+				);
+			case "dateUpdated-desc":
+				return (
+					new Date(b.dateUpdated).getTime() - new Date(a.dateUpdated).getTime()
+				);
+			case "dateUpdated-asc":
+				return (
+					new Date(a.dateUpdated).getTime() - new Date(b.dateUpdated).getTime()
+				);
+			case "priority-desc":
+				return priorityMap[b.priority] - priorityMap[a.priority];
+			case "priority-asc":
+				return priorityMap[a.priority] - priorityMap[b.priority];
+			case "title-asc":
+				return a.title.localeCompare(b.title);
+			case "title-desc":
+				return b.title.localeCompare(a.title);
+			default:
+				return 0;
+		}
+	});
+
+	return sortedIdeas;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,3 +22,13 @@ export interface FilterOptions {
 	selectedTags: string[];
 	priority: string;
 }
+
+export type SortOption =
+	| "dateCreated-desc"
+	| "dateCreated-asc"
+	| "dateUpdated-desc"
+	| "dateUpdated-asc"
+	| "priority-desc"
+	| "priority-asc"
+	| "title-asc"
+	| "title-desc";


### PR DESCRIPTION
This commit introduces an advanced sorting feature to the project idea tracker.

A 'Sort by' dropdown has been added to the search and filter bar, allowing users to sort the list of ideas by various criteria.

The following sorting options are now available:
- Date Created (Newest/Oldest)
- Date Updated (Newest/Oldest)
- Priority (High to Low/Low to High)
- Title (A-Z/Z-A)

The sorting is performed client-side and works in conjunction with the existing search and filter functionality.